### PR TITLE
誤変換を修正

### DIFF
--- a/l10n-central/ja-KA/browser/browser/preferences/preferences.ftl
+++ b/l10n-central/ja-KA/browser/browser/preferences/preferences.ftl
@@ -940,7 +940,7 @@ enhanced-tracking-protection-setting-custom =
 
 ##
 
-content-blocking-etp-standard-desc = 保護と性能をバランスよくな。ページが正しく機能しとくように読み込無で。
+content-blocking-etp-standard-desc = 保護と性能をバランスよくな。ページが正しく機能しとくように読み込むで。
 content-blocking-etp-strict-desc = より強固な保護やけど、一部のサイトやコンテンツが機能しなくなるかもしれへん。
 content-blocking-etp-custom-desc = ブロックしとくトラッカーとスクリプトを選択すんで。
 content-blocking-etp-blocking-desc = { -brand-short-name } は以下のものをブロックすんで:


### PR DESCRIPTION
関西弁の強化型トラッキング防止機能の設定で「読み込む」が「読み込無」になっていたので修正しました。