### PR TITLE
ら抜き言葉を修正

### DIFF
--- a/l10n-central/ja-KA/browser/browser/preferences/moreFromMozilla.ftl
+++ b/l10n-central/ja-KA/browser/browser/preferences/moreFromMozilla.ftl
@@ -33,7 +33,7 @@ about-ablaze = Ablaze ってなんぞや
 ablaze-twitter = Ablaze の URL : Twitter <label data-l10n-name="ablaze-twitter-id">@Ablaze_MIRAI</label>　Github : <label data-l10n-name="ablaze-github-id">@Ablaze-MIRAI</label>　alexandriteOS  : <label data-l10n-name="alexandriteos-url">公式サイト</label>
 about-ablaze-sub = AblazeはFloorpプロジェクトの上にあるグループで、Floorpを開発しており、FloorpプロジェクトはFloorpのサポートを受けながら、ここで運営されとるんやで。他にも、AlexandriteOSなどのプロジェクトもやっとるで。
 about-floorp = Floorp プロジェクトってなんぞや
-about-floorp-sub = Floorpプロジェクトは Ablaze 傘下のプロジェクトで、Floorp Legacy ブラウザは開発製品で、Mozillaが開発したFirefoxブラウザをベースとしとるで。このプロジェクトは、すべて非営利で開発されてとるで。より充実したブラウジングを楽しんでくれ。ソースコードは、下のGithubリンクから見れるで。
+about-floorp-sub = Floorpプロジェクトは Ablaze 傘下のプロジェクトで、Floorp Legacy ブラウザは開発製品で、Mozillaが開発したFirefoxブラウザをベースとしとるで。このプロジェクトは、すべて非営利で開発されてとるで。より充実したブラウジングを楽しんでくれ。ソースコードは、下のGithubリンクから見られるで。
 floorp-twitter = Floorp の URL : Twitter <label data-l10n-name="floorp-twitter-id">@Floorp_Browser</label>　Github : <label data-l10n-name="floorp-github-id">@Floorp-Projects</label>　Floorp のサイト : <label data-l10n-name="floorp-official-url">公式サイト</label>
 about-floorp-sub-sub = Ablaze Floorp
 about-legacy = Ablaze Floorp ってなんぞや


### PR DESCRIPTION
関西弁の設定画面の「Ablaze と Floorp ってなんぞや」内の「Floorp プロジェクトってなんぞや」の項目で、「ソースコードは、下のGithubリンクから見れるで」の「見れる」を「見られる」に修正しました。

関西の方にとっては「見られるで」よりも「見れるで」のほうが自然なのかもしれませんが、過去にMozillaの日本語ローカライズリポジトリでら抜き言葉を修正したというPull Requestを見つけたので送らせていただきました。

mozilla-japan/gecko-l10n#271

