### PR TITLE
ja: 助詞抜けを修正

### DIFF
--- a/l10n-central/ja/browser/browser/floorp.ftl
+++ b/l10n-central/ja/browser/browser/floorp.ftl
@@ -213,7 +213,7 @@ sidebar-preferences = ブラウザーマネージャーサイドバーの設定
 view-sidebar2-right = 
  .label = サイドバーを右側に表示する
 enable-sidebar2 =
- .label = ブラウザーマネージャーサイドバー有効にする
+ .label = ブラウザーマネージャーサイドバーを有効にする
 
 sidebar2-restore =
  .label = サイドバーを再起動時・新しいウインドウ作成時に復元する


### PR DESCRIPTION
設定画面において「ブラウザーマネージャーサイドバー有効にする」と、助詞が抜けていたため修正させていただきました。ご確認お願い致します。