### PR TITLE
es-mx Fix mistakes made by automatic translation

### DIFF
--- a/l10n-central/es-MX/chat/status.properties
+++ b/l10n-central/es-MX/chat/status.properties
@@ -20,4 +20,4 @@ statusWithStatusMessage=%1$S - %2$S
 
 # LOCALIZATION NOTE (messenger.status.defaultIdleAwayMessage):
 #  This will be the away message put automatically when the user is idle.
-messenger.status.defaultIdleAwayMessage=Actualmente estoy lejos del equipo.
+messenger.status.defaultIdleAwayMessage=Actualmente estas lejos del equipo.

--- a/l10n-central/es-MX/chat/yahoo.properties
+++ b/l10n-central/es-MX/chat/yahoo.properties
@@ -2,4 +2,4 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-yahoo.disabled=Yahoo Messenger ya no es compatible debido a que Yahoo deshabilitó su legado de protocolo.
+yahoo.disabled=Yahoo Messenger ya no es soportado debido a que Yahoo deshabilitó su protocolo heredado.


### PR DESCRIPTION
Legacy systems in spanish are called _"sistemas heredados"_ https://es.wikipedia.org/wiki/Sistema_heredado

`messenger.status.defaultIdleAwayMessage` is written in first person